### PR TITLE
Better auto tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,67 +112,36 @@ def multiply_numbers(session: Session, nums: Integers) -> None:
 ## Automatic Tags
 
 An additional nicety of NoxOpt is that is can automatically create tags based on the
-names of your sessions using the `auto_tag_depth` parameter. The idea behind this
-parameter is that if you have a set of sessions with a common naming scheme - for example:
-
-- `check-python-tests`
-- `check-python-format`
-- `check-javascript-tests`
-- `check-javascript-format`
-
-One might find it useful to be able to run say, all the sessions begining with
-`check-python`. Thankfully if you set `NoxOpt(auto_tag_depth=2)`, NoxOpt will split
-every session name on `-` characters and generate tags based on the first two words in
-each. In this case, the set of tags would be:
-
-- `check`
-- `check-python`
-- `check-javascript`
-
-If you wish to disable this behavior in a given session you can set
-`NoxOpt.session(tags=None)` when defining it.
-
-## Using Multiple Nox Option Groups
-
-It may be useful to divide sessions into different `NoxOpt` groups. This could be
-because there a sessions that need to re-use the same parameter name, but with different
-option setting, or because you need more control over automatic tags. To do this, all
-you need to do is create two separate `NoxOpt` instances and add sessions to them.
-
-The example below uses two `NoxOpt` instance to generate the following tags:
-
-- `format`
-- `check`
-- `check-python`
-- `check-javascript`
+names of your sessions using the `NoxOpt(auto_tag=True)` parameter. The idea behind this
+parameter is that if you have a set of sessions with a common naming scheme like:
 
 ```python
 from noxopt import NoxOpt, Session
 
-formatters = NoxOpt(auto_tag_depth=1)
-checkers = NoxOpt(auto_tag_depth=2)
+nox = NoxOpt(auto_tag=True)
 
-@formatters.session
-def format_python(session: Session) -> None:
-    ...
-
-@formatters.session
-def format_javascript(session: Session) -> None:
-    ...
-
-@checkers.session
+@nox.session
 def check_python_tests(session: Session) -> None:
     ...
 
-@checkers.session
+@nox.session
 def check_python_format(session: Session) -> None:
     ...
 
-@checkers.session
+@nox.session
 def check_javascript_tests(session: Session) -> None:
     ...
 
-@checkers.session
+@nox.session
 def check_javascript_format(session: Session) -> None:
     ...
 ```
+
+NoxOpt will generate the following tags:
+
+- `check` - run sessions begining with `check`
+- `check-python` - run sessions begining with `check-python`
+- `check-javascript`- run sessions begining with `check-javascript`
+
+It does this by splitting every session name in the group on `-` characters and creating
+tags based on their common prefixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "noxopt"
+version = "0.0.4"
 description = "Nox sessions with options"
 authors = [
     {name = "Ryan Morshead", email = "ryan.morshead@gmail.com"},
@@ -15,7 +16,6 @@ classifiers = [
     "Framework :: Django",
     "Programming Language :: Python :: 3",
 ]
-version = "0.0.3"
 dependencies = [
     "nox",
     'importlib-metadata; python_version<"3.8"',

--- a/tests/test_noxopt.py
+++ b/tests/test_noxopt.py
@@ -163,65 +163,35 @@ def tests_error_on_conflicting_options(execute: Executor):
 
 
 def test_auto_tags_no_prefix(registry):
-    app = NoxOpt(auto_tag_depth=2)
+    app = NoxOpt(auto_tag=True)
 
     @app.session
-    def check_python_tests(session: Session) -> None:
+    def a_x_1(session: Session) -> None:
         ...
 
     @app.session
-    def check_python_format(session: Session) -> None:
+    def a_x_2(session: Session) -> None:
         ...
 
     @app.session
-    def check_javascript_tests(session: Session) -> None:
+    def a_y_1(session: Session) -> None:
         ...
 
     @app.session
-    def check_javascript_format(session: Session) -> None:
-        ...
-
-    assert set(registry["check-python-tests"].tags) == {"check-python", "check"}
-    assert set(registry["check-python-format"].tags) == {"check-python", "check"}
-    assert set(registry["check-javascript-tests"].tags) == {"check-javascript", "check"}
-    assert set(registry["check-javascript-format"].tags) == {
-        "check-javascript",
-        "check",
-    }
-
-
-def test_auto_tags_with_prefix(registry):
-    app = NoxOpt(auto_tag_depth=2, prefix="session-prefix")
-
-    @app.session
-    def check_python_tests(session: Session) -> None:
+    def a_y_2(session: Session) -> None:
         ...
 
     @app.session
-    def check_python_format(session: Session) -> None:
+    def b_x_1(session: Session) -> None:
         ...
 
     @app.session
-    def check_javascript_tests(session: Session) -> None:
+    def b_x_2(session: Session) -> None:
         ...
 
-    @app.session
-    def check_javascript_format(session: Session) -> None:
-        ...
-
-    assert set(registry["session-prefix-check-python-tests"].tags) == {
-        "session-prefix-check-python",
-        "session-prefix-check",
-    }
-    assert set(registry["session-prefix-check-python-format"].tags) == {
-        "session-prefix-check-python",
-        "session-prefix-check",
-    }
-    assert set(registry["session-prefix-check-javascript-tests"].tags) == {
-        "session-prefix-check-javascript",
-        "session-prefix-check",
-    }
-    assert set(registry["session-prefix-check-javascript-format"].tags) == {
-        "session-prefix-check-javascript",
-        "session-prefix-check",
-    }
+    assert set(registry["a-x-1"].tags) == {"a", "a-x"}
+    assert set(registry["a-x-2"].tags) == {"a", "a-x"}
+    assert set(registry["a-y-1"].tags) == {"a", "a-y"}
+    assert set(registry["a-y-2"].tags) == {"a", "a-y"}
+    assert set(registry["b-x-1"].tags) == {"b-x"}
+    assert set(registry["b-x-2"].tags) == {"b-x"}


### PR DESCRIPTION
Instead of declaring `auto_tag_depth=some_int`. You can now just set `auto_tag=True` and NoxOpt will more intelligently generate tags for your sessions. It does this by constructing a graph of words, and at every branching point in the graph it creates a tag. For example the session names:

- `a-x-1`
- `a-x-2`
- `a-y-1`
- `a-y-2`
- `b-x-1`
- `b-x-2`

Would create the graph:

```
      *
     / \
    a   b
   /\    \
  x  y    x
 /|  |\   |\
1 2  1 2  1 2
```

At every branching point in the graph a tag would be generated and applied to all functions with that prefix. So the tags would be:

- `a`
- `a-x`
- `a-y`
- `b-x`

## Checklist

Please update this checklist as you complete each item:

- [X] Tests have been included for all bug fixes or added functionality.
- [X] GitHub Issues which may be closed by this Pull Request have been linked.
